### PR TITLE
Add upper bounds on composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 
 	"require": {
 		"php":          ">=5.3",
-		"behat/behat":  ">=2.4",
-		"behat/mink":   ">=1.4",
-		"behat/mink-extension":   ">=1.2"
+		"behat/behat":  "~2.4",
+		"behat/mink":   "~1.4",
+		"behat/mink-extension":   "~1.2"
 	},
 
     "autoload": {


### PR DESCRIPTION
The Behat extension available in this package is not compatible with Behat 3. So the upper bound is necessary (in general, an upper bound should always be used)
